### PR TITLE
feat: implement image compression backend API

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.0.5
 	go.uber.org/zap v1.27.1
+	golang.org/x/image v0.23.0
 	golang.org/x/oauth2 v0.24.0
 	google.golang.org/api v0.205.0
 	gorm.io/datatypes v1.2.7

--- a/backend/internal/handlers/compress.go
+++ b/backend/internal/handlers/compress.go
@@ -1,0 +1,139 @@
+package handlers
+
+import (
+	"net/http"
+
+	"vibe-backend/internal/services"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// CompressHandler handles image compression requests.
+type CompressHandler struct {
+	imageService *services.ImageService
+	log          *zap.Logger
+}
+
+// NewCompressHandler creates a new CompressHandler.
+func NewCompressHandler(imageService *services.ImageService, log *zap.Logger) *CompressHandler {
+	return &CompressHandler{
+		imageService: imageService,
+		log:          log,
+	}
+}
+
+// CompressRequest represents the request for image compression.
+type CompressRequest struct {
+	MaxWidth  *int     `form:"maxWidth"`
+	MaxHeight *int     `form:"maxHeight"`
+	Quality   *float64 `form:"quality"`
+}
+
+// CompressResponse represents the response for image compression.
+type CompressResponse struct {
+	Success         bool   `json:"success"`
+	Message         string `json:"message"`
+	CompressedImage string `json:"compressedImage,omitempty"`
+	OriginalSize    int64  `json:"originalSize,omitempty"`
+	CompressedSize  int64  `json:"compressedSize,omitempty"`
+}
+
+// ErrorResponse represents an error response.
+type ErrorResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
+// Compress handles POST /api/compress requests.
+func (h *CompressHandler) Compress(c *gin.Context) {
+	requestID := c.GetString("request_id")
+
+	// Parse form data
+	var req CompressRequest
+	if err := c.ShouldBind(&req); err != nil {
+		h.log.Error("Failed to bind request",
+			zap.Error(err),
+			zap.String("request_id", requestID),
+		)
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Success: false,
+			Message: "Invalid request parameters: " + err.Error(),
+		})
+		return
+	}
+
+	// Get uploaded file
+	file, err := c.FormFile("image")
+	if err != nil {
+		h.log.Error("Failed to get uploaded file",
+			zap.Error(err),
+			zap.String("request_id", requestID),
+		)
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Success: false,
+			Message: "No image file provided or invalid file upload",
+		})
+		return
+	}
+
+	h.log.Info("Compress request received",
+		zap.String("filename", file.Filename),
+		zap.Int64("size", file.Size),
+		zap.String("request_id", requestID),
+	)
+
+	// Set default quality if not provided
+	quality := 0.8
+	if req.Quality != nil {
+		quality = *req.Quality
+	}
+
+	// Process the image
+	options := services.ProcessOptions{
+		MaxWidth:  req.MaxWidth,
+		MaxHeight: req.MaxHeight,
+		Quality:   quality,
+	}
+
+	result, err := h.imageService.ProcessImage(file, options)
+	if err != nil {
+		h.handleCompressError(c, err, requestID)
+		return
+	}
+
+	// Return success response
+	c.JSON(http.StatusOK, CompressResponse{
+		Success:         true,
+		Message:         "图片压缩成功",
+		CompressedImage: result.CompressedImage,
+		OriginalSize:    result.OriginalSize,
+		CompressedSize:  result.CompressedSize,
+	})
+}
+
+// handleCompressError handles compression errors and returns appropriate HTTP responses.
+func (h *CompressHandler) handleCompressError(c *gin.Context, err error, requestID string) {
+	h.log.Error("Compress error",
+		zap.Error(err),
+		zap.String("request_id", requestID),
+	)
+
+	switch err {
+	case services.ErrInvalidImageFormat:
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Success: false,
+			Message: "不支持的图片格式，仅支持 JPEG、PNG 和 GIF 格式",
+		})
+	case services.ErrFileTooLarge:
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Success: false,
+			Message: "文件过大，最大支持 10MB",
+		})
+	default:
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Success: false,
+			Message: "图片处理失败，请稍后重试",
+		})
+	}
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -86,6 +86,10 @@ func New(cfg *config.Config, db *database.PostgresDB, cache *cache.RedisCache, l
 	chatService := services.NewChatService(chatRepo, videoRepo, insightRepo, cfg.OpenRouterAPIKey, cfg.GeminiModel, log)
 	chatHandler := handlers.NewChatHandler(chatService, log)
 
+	// Image compression handler (no database required)
+	imageService := services.NewImageService(log)
+	compressHandler := handlers.NewCompressHandler(imageService, log)
+
 	// API routes
 	api := r.Group("/api")
 	{
@@ -106,6 +110,9 @@ func New(cfg *config.Config, db *database.PostgresDB, cache *cache.RedisCache, l
 
 		// Parse routes
 		api.POST("/parse", parseHandler.Parse)
+
+		// Image compression route
+		api.POST("/compress", compressHandler.Compress)
 
 		// Analysis routes
 		analysis := api.Group("/analysis")

--- a/backend/internal/services/image.go
+++ b/backend/internal/services/image.go
@@ -1,0 +1,217 @@
+package services
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"image"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"io"
+	"mime/multipart"
+	"strings"
+
+	"go.uber.org/zap"
+	"golang.org/x/image/draw"
+)
+
+var (
+	// ErrInvalidImageFormat is returned when the image format is not supported.
+	ErrInvalidImageFormat = errors.New("invalid image format: only JPEG, PNG, and GIF are supported")
+	// ErrFileTooLarge is returned when the file size exceeds the limit.
+	ErrFileTooLarge = errors.New("file too large: maximum size is 10MB")
+	// ErrProcessingFailed is returned when image processing fails.
+	ErrProcessingFailed = errors.New("image processing failed")
+)
+
+const (
+	// MaxFileSize is the maximum allowed file size (10MB)
+	MaxFileSize = 10 * 1024 * 1024
+)
+
+// ImageService handles image compression and resizing operations.
+type ImageService struct {
+	log *zap.Logger
+}
+
+// NewImageService creates a new ImageService.
+func NewImageService(log *zap.Logger) *ImageService {
+	return &ImageService{log: log}
+}
+
+// ProcessOptions contains options for image processing.
+type ProcessOptions struct {
+	MaxWidth  *int
+	MaxHeight *int
+	Quality   float64
+}
+
+// ProcessResult contains the result of image processing.
+type ProcessResult struct {
+	CompressedImage string
+	OriginalSize    int64
+	CompressedSize  int64
+	Format          string
+}
+
+// ProcessImage processes an uploaded image with compression and/or resizing.
+func (s *ImageService) ProcessImage(file *multipart.FileHeader, options ProcessOptions) (*ProcessResult, error) {
+	// Validate file size
+	if file.Size > MaxFileSize {
+		return nil, ErrFileTooLarge
+	}
+
+	// Open the file
+	src, err := file.Open()
+	if err != nil {
+		s.log.Error("Failed to open uploaded file", zap.Error(err))
+		return nil, ErrProcessingFailed
+	}
+	defer src.Close()
+
+	// Read the file content
+	fileData, err := io.ReadAll(src)
+	if err != nil {
+		s.log.Error("Failed to read file data", zap.Error(err))
+		return nil, ErrProcessingFailed
+	}
+
+	// Detect image format and decode
+	img, format, err := image.Decode(bytes.NewReader(fileData))
+	if err != nil {
+		s.log.Error("Failed to decode image", zap.Error(err))
+		return nil, ErrInvalidImageFormat
+	}
+
+	// Validate format
+	format = strings.ToLower(format)
+	if format != "jpeg" && format != "png" && format != "gif" {
+		return nil, ErrInvalidImageFormat
+	}
+
+	s.log.Info("Processing image",
+		zap.String("format", format),
+		zap.Int64("original_size", file.Size),
+		zap.Int("width", img.Bounds().Dx()),
+		zap.Int("height", img.Bounds().Dy()),
+	)
+
+	// Resize if needed
+	processedImg := img
+	if options.MaxWidth != nil || options.MaxHeight != nil {
+		processedImg = s.resizeImage(img, options.MaxWidth, options.MaxHeight)
+	}
+
+	// Compress and encode
+	var buf bytes.Buffer
+	if err := s.encodeImage(&buf, processedImg, format, options.Quality); err != nil {
+		s.log.Error("Failed to encode image", zap.Error(err))
+		return nil, ErrProcessingFailed
+	}
+
+	// Convert to base64
+	compressedData := buf.Bytes()
+	base64Data := base64.StdEncoding.EncodeToString(compressedData)
+	dataURL := fmt.Sprintf("data:image/%s;base64,%s", format, base64Data)
+
+	result := &ProcessResult{
+		CompressedImage: dataURL,
+		OriginalSize:    file.Size,
+		CompressedSize:  int64(len(compressedData)),
+		Format:          format,
+	}
+
+	s.log.Info("Image processed successfully",
+		zap.Int64("original_size", result.OriginalSize),
+		zap.Int64("compressed_size", result.CompressedSize),
+		zap.Float64("compression_ratio", float64(result.OriginalSize-result.CompressedSize)/float64(result.OriginalSize)*100),
+	)
+
+	return result, nil
+}
+
+// resizeImage resizes an image while maintaining aspect ratio.
+func (s *ImageService) resizeImage(img image.Image, maxWidth, maxHeight *int) image.Image {
+	bounds := img.Bounds()
+	currentWidth := bounds.Dx()
+	currentHeight := bounds.Dy()
+
+	// If no constraints, return original
+	if maxWidth == nil && maxHeight == nil {
+		return img
+	}
+
+	// Calculate new dimensions
+	newWidth := currentWidth
+	newHeight := currentHeight
+
+	if maxWidth != nil && currentWidth > *maxWidth {
+		ratio := float64(*maxWidth) / float64(currentWidth)
+		newWidth = *maxWidth
+		newHeight = int(float64(currentHeight) * ratio)
+	}
+
+	if maxHeight != nil && newHeight > *maxHeight {
+		ratio := float64(*maxHeight) / float64(newHeight)
+		newHeight = *maxHeight
+		newWidth = int(float64(newWidth) * ratio)
+	}
+
+	// If no resize needed, return original
+	if newWidth == currentWidth && newHeight == currentHeight {
+		return img
+	}
+
+	s.log.Info("Resizing image",
+		zap.Int("from_width", currentWidth),
+		zap.Int("from_height", currentHeight),
+		zap.Int("to_width", newWidth),
+		zap.Int("to_height", newHeight),
+	)
+
+	// Create new image
+	dst := image.NewRGBA(image.Rect(0, 0, newWidth, newHeight))
+
+	// Resize using Catmull-Rom interpolation for high quality
+	draw.CatmullRom.Scale(dst, dst.Bounds(), img, img.Bounds(), draw.Over, nil)
+
+	return dst
+}
+
+// encodeImage encodes an image to the specified format with quality settings.
+func (s *ImageService) encodeImage(w io.Writer, img image.Image, format string, quality float64) error {
+	// Ensure quality is in valid range
+	if quality < 0 {
+		quality = 0
+	}
+	if quality > 1 {
+		quality = 1
+	}
+
+	switch format {
+	case "jpeg":
+		// JPEG quality: 1-100
+		jpegQuality := int(quality * 100)
+		if jpegQuality < 1 {
+			jpegQuality = 1
+		}
+		if jpegQuality > 100 {
+			jpegQuality = 100
+		}
+		return jpeg.Encode(w, img, &jpeg.Options{Quality: jpegQuality})
+
+	case "png":
+		// PNG compression (quality doesn't directly apply, but we use default encoder)
+		encoder := png.Encoder{CompressionLevel: png.DefaultCompression}
+		return encoder.Encode(w, img)
+
+	case "gif":
+		// GIF encoding (quality doesn't apply)
+		return gif.Encode(w, img, nil)
+
+	default:
+		return ErrInvalidImageFormat
+	}
+}


### PR DESCRIPTION
## Summary

Implements the backend API for image compression and resizing as specified in issue #1.

## Features

- POST /api/compress endpoint
- Support for JPEG, PNG, and GIF formats
- File size limit (10MB max)
- Quality adjustment (0-1 scale)
- Width/height constraints with aspect ratio preservation
- Base64-encoded response with compression stats
- Comprehensive error handling

## Technical Details

- Uses golang.org/x/image for high-quality image processing
- Catmull-Rom interpolation for resizing
- Follows existing backend patterns and conventions
- Includes request ID tracking and structured logging

Closes #1

Generated with [Claude Code](https://claude.ai/code)